### PR TITLE
Make the "Open DOT Visualizer" button directly open the generated graph

### DIFF
--- a/Editor/Backends/DotGraphBackend.cs
+++ b/Editor/Backends/DotGraphBackend.cs
@@ -6,7 +6,7 @@ namespace RRCG
 {
     public class DotGraphBackend
     {
-        public static void Build(Context context)
+        public static string Build(Context context)
         {
             var dotGraph = $@"digraph RRCG {{
 {string.Join("\n", context.Nodes.Select((node, i) => $"    {i} [label=\"{GetNodeName(node)}\"];"))}
@@ -15,8 +15,7 @@ namespace RRCG
 }}
 ";
             Debug.Log(dotGraph);
-            GUIUtility.systemCopyBuffer = dotGraph;
-            Debug.Log("dotGraph copied");
+            return dotGraph;
         }
 
         private static string GetNodeName(Node node)

--- a/Editor/UI/Inspectors/RRCGInspector.cs
+++ b/Editor/UI/Inspectors/RRCGInspector.cs
@@ -42,14 +42,19 @@ namespace RRCG
 
             if (GUILayout.Button("Open DOT Visualizer"))
             {
-                Application.OpenURL("https://dreampuf.github.io/GraphvizOnline/");
+                var context = await RoslynFrontend.GetBuilt(rrcgMeta);
+                if (EnableOptimizer) context = GraphOptimizer.Optimize(context);
+                var dotGraph = DotGraphBackend.Build(context);
+                Application.OpenURL("https://dreampuf.github.io/GraphvizOnline/#" + Uri.EscapeDataString(dotGraph));
             }
 
             if (GUILayout.Button("Copy DOT Graph"))
             {
                 var context = await RoslynFrontend.GetBuilt(rrcgMeta);
                 if (EnableOptimizer) context = GraphOptimizer.Optimize(context);
-                DotGraphBackend.Build(context);
+                var dotGraph = DotGraphBackend.Build(context);
+                GUIUtility.systemCopyBuffer = dotGraph;
+                Debug.Log("dotGraph copied");
             }
         }
     }


### PR DESCRIPTION
A simple change, please let me know if there is a different way you would want to do this, such as if you would prefer to instead make it a param passed into DotGraphBackend.Build to open the visualizer