### PR TITLE
Improved DOT visualization

### DIFF
--- a/Editor/Backends/DotGraphBackend.cs
+++ b/Editor/Backends/DotGraphBackend.cs
@@ -1,4 +1,5 @@
-using RRCGBuild;
+﻿using RRCGBuild;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -8,14 +9,67 @@ namespace RRCG
     {
         public static string Build(Context context)
         {
-            var dotGraph = $@"digraph RRCG {{
-{string.Join("\n", context.Nodes.Select((node, i) => $"    {i} [label=\"{GetNodeName(node)}\"];"))}
+            var defaultValues = new List<(int node, int group, int port, object value)>();
+            for (int n = 0; n < context.Nodes.Count; n++)
+            {
+                foreach (var ((g, p), v) in context.Nodes[n].DefaultValues)
+                {
+                    defaultValues.Add((n, g, p, v));
+                }
+            }
 
-{string.Join("\n", context.Connections.Select((Connection, i) => $"   {context.Nodes.IndexOf(Connection.From.Node)} -> {context.Nodes.IndexOf(Connection.To.Node)};"))}
+            var dotGraph = $@"digraph RRCG {{
+
+    // Nodes
+{string.Join("\n", context.Nodes.Select((node, i) => $"    {i} [label=\"{GetNodeName(node)}\", shape=rect, style=rounded];"))}
+
+    // Port default values
+{string.Join("\n", defaultValues.Select((value, i) => $"    {context.Nodes.Count + i} [label=\"{value.value}\", color=\"{GetTypeColor(value.value)}\", shape=diamond];"))}
+
+    // Edges
+{string.Join("\n", context.Connections.Select((Connection, i) =>
+$"    {context.Nodes.IndexOf(Connection.From.Node)} -> {context.Nodes.IndexOf(Connection.To.Node)} [color=\"{GetEdgeColor(Connection)}\", label=\"{GetEdgePortIdDescriptor(Connection)}\"];"))}
+
+    // Default value connections
+{string.Join("\n", defaultValues.Select((value, i) => $"    {context.Nodes.Count + i} -> {value.node} [color=black, label=\"{GetPortIdDescriptor(value.group, value.port)}\"];"))}
 }}
 ";
             Debug.Log(dotGraph);
             return dotGraph;
+        }
+
+        private static string GetEdgeColor(Connection connection)
+        {
+            return connection.isExec ? "#F55C1A" : "black";
+        }
+
+        private static string GetPortIdDescriptor(int group, int port) =>
+            group == 0 ? port.ToString() : $"[{group}, {port}]";
+
+        private static string GetEdgePortIdDescriptor(Connection connection)
+        {
+            static string getPortIds(Port port) => GetPortIdDescriptor(port.Group, port.Index);
+            return $"{getPortIds(connection.From)} → {getPortIds(connection.To)}";
+        }
+
+        private static string GetTypeColor(object defaultValue)
+        {
+            switch (defaultValue)
+            {
+                case int:
+                    return "#2B6738";
+                case float:
+                    return "#186BDD";
+                case bool:
+                    return "#EA2E50";
+                case string:
+                    return "#784283";
+                case Color:
+                case Color32:
+                    return "#14317D";
+                default:
+                    return "#F5C51F";
+            }
         }
 
         private static string GetNodeName(Node node)


### PR DESCRIPTION
Made various improvements to the DOT generation process in `DotGraphBackend`:
- Exec edges are rendered in orange, as they are in the client.
- The port indices from the source and destination node are included as labels on each edge. The port group index is included if it is nonzero, as it will be with all non-board nodes.
- Default values are included in the graph:
   - They are represented by individual nodes, labelled with their value and contained in a diamond.
   - They have a directed edge to their associated node, which is labelled with the port index.
   - The node border is colored according to its type, using the same colors as the client.
- Nodes representing chips are now rendered in rounded rectangles, to better match the shape of chips in the client.

A generated DOT file and its rendered SVG for the included example script are included below.
[example.txt](https://github.com/user-attachments/files/17842551/example.txt) (GitHub does not support .dot)
![graphviz](https://github.com/user-attachments/assets/bb716e68-6cb8-40e2-8be6-49771d994e76)
